### PR TITLE
fix: explicitly define files to publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,5 +31,11 @@
   },
   "engines": {
     "node": ">=18.0.0"
-  }
+  },
+  "files": [
+    "LICENSE",
+    "README.md",
+    "index.js",
+    "package.json"
+  ]
 }


### PR DESCRIPTION
This is a small change to remove unnecessary files from the published package. Works by using `package.json` to specify which files _should_ be included when publishing, rather than block-listing files.