### PR TITLE
feat: implement automatic retries on rate limit

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,12 +34,11 @@ class AutotaskRestApi {
    * @param {string} options.version Autotask REST API decimal version (e.g. 1.0). (Default 1.0);
    * @param {object?} options.retry Retry options for the connector.
    * @param {boolean?} options.retry.enabled If true, will retry the request as configured. (Default true)
-   * @param {number?} options.retry.attempts If retry_on_error is true, the number of times to retry the request.
-   *  (Default 10)
-   * @param {number?} options.retry.delay If retry_on_error is true, the number of milliseconds to wait before trying
-   *  again. (Default 1000)
-   * @param {number?} options.retry.delay_factor If retry_on_error is true, the factor by which to increase the delay
-   *  between retries. (Default 2)
+   * @param {number?} options.retry.attempts If enabled, the number of times to retry the request. (Default 10)
+   * @param {number?} options.retry.delay If enabled, the number of milliseconds to wait before trying again.
+   *  (Default 1000)
+   * @param {number?} options.retry.delay_factor If enabled, the factor by which to increase the delay between retries.
+   *  (Default 2)
    */
   constructor(user, secret, code, options){
     if(!user)throw new Error(`An API user is required.`);

--- a/index.test.js
+++ b/index.test.js
@@ -1,5 +1,5 @@
 require('dotenv').config();
-let {AutotaskRestApi, FilterOperators} = require('.');
+let {AutotaskRestApi, FilterOperators, AutotaskApiError} = require('.');
 var autotask = null;
 
 beforeAll(async ()=>{
@@ -24,6 +24,33 @@ it('can get by id', async () => {
   expect(company).toBeDefined();
   expect(company.id).toBe(0);
 });
+
+describe('retries', () => {
+  it('should retry on 429', async () => {
+    // Mock fetch to return 429 once, then reset.
+    const fetchMock = jest.spyOn(global, 'fetch').mockImplementationOnce(() => Promise.resolve({
+      status: 429, ok: false, json: () => Promise.resolve({}),
+    }));
+
+    let result = await autotask.Companies.get(0);
+    let company = result.item
+
+    expect(company).toBeDefined();
+    expect(company.id).toBe(0);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  })
+
+  it('should not retry if disabled', async () => {
+    // Mock fetch to return 429 once, then reset.
+    const fetchMock = jest.spyOn(global, 'fetch').mockImplementationOnce(() => Promise.resolve({
+      status: 429, ok: false, text: () => Promise.resolve('')
+    }));
+    jest.replaceProperty(autotask.retryOptions, 'enabled', false);
+
+    await expect(autotask.Companies.get(0)).rejects.toThrow(AutotaskApiError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  })
+})
 
 test('can query multiple.', async () => {
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,10 +1,6 @@
 /** @type {import('jest').Config} */
 const config = {
-  // Since these are integration tests with a relatively slow API, increase the timeout to 20s.
-  testTimeout: 20_000,
   clearMocks: true,
-  // Increase timeout from the default of 1s to 5s to allow time for fetch's TCPWRAP and TLSWRAP handles to close.
-  openHandlesTimeout: 5_000
 };
 
 module.exports = config;

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,10 @@
+/** @type {import('jest').Config} */
+const config = {
+  // Since these are integration tests with a relatively slow API, increase the timeout to 20s.
+  testTimeout: 20_000,
+  clearMocks: true,
+  // Increase timeout from the default of 1s to 5s to allow time for fetch's TCPWRAP and TLSWRAP handles to close.
+  openHandlesTimeout: 5_000
+};
+
+module.exports = config;


### PR DESCRIPTION
This pull request adds a feature to allow the Autotask client to automatically retry any requests that were rate-limited (i.e. receives the `429` HTTP code, per [Autotask's documentation](https://autotask.net/help/DeveloperHelp/Content/APIs/General/ThreadLimiting.htm)).

The retry will [exponentially back off](https://docs.aws.amazon.com/prescriptive-guidance/latest/cloud-design-patterns/retry-backoff.html) between attempts on subsequent rate limits for the same request. Once it reaches the specified maximum number of retries, it will return the errored request object back to the API client's `_fetch` method for handling like normal.

This is done by wrapping the `fetch` built-in function within the `_fetch` client method. It's enabled by default, but if someone needs the old functionality for whatever reason, they can disable it when initializing the client class.

Tests have been added to ensure the functionality works as intended and can be disabled, as well as ensuring that no existing tests have broken (including error handling).