### PR TITLE
feat: add support for TimeOffRequests and sub-entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,7 @@ The following is a list of all Autotask entities supported by the connector:
 * TicketCategories
 * TicketHistory
 * TimeEntries
+* TimeOffRequests
 * UserDefinedFieldDefinitions
 * WebhookEventErrorLogs
 * WorkTypeModifiers
@@ -576,6 +577,8 @@ The REST API introduces a parent-child relationship among some Autotask entities
 * TicketRmaCredits &rarr; Tickets/RmaCredits
 * TicketSecondaryResources &rarr; Tickets/SecondaryResources
 * TimeEntryAttachments &rarr; TimeEntries/Attachments
+* TimeOffRequestsApprove &rarr; TimeOffRequests/Approve
+* TimeOffRequestsReject &rarr; TimeOffRequests/Reject
 * UserDefinedFieldListItems &rarr; UserDefinedFields/ListItems
 
 ## Error Handling

--- a/index.js
+++ b/index.js
@@ -224,6 +224,9 @@ class AutotaskRestApi {
       {name:'TicketSecondaryResources', childOf: 'Tickets', subname: 'SecondaryResources'},
       {name:'TimeEntries'},
       {name:'TimeEntryAttachments', childOf: 'TimeEntries', subname: 'Attachments'},
+      {name:'TimeOffRequestsApprove', childOf: 'TimeOffRequests', subname: 'Approve'},
+      {name:'TimeOffRequests'},
+      {name:'TimeOffRequestsReject', childOf: 'TimeOffRequests', subname: 'Reject'},
       {name:'UserDefinedFieldDefinitions'},
       {name:'UserDefinedFieldListItems', childOf: 'UserDefinedFields', subname: 'ListItems'},//note, no parent native entity
       {name:'WebhookEventErrorLogs'},


### PR DESCRIPTION
Add support for the following entities:

- [`TimeOffRequests`](https://autotask.net/help/DeveloperHelp/Content/APIs/REST/Entities/TimeOffRequestsEntity.htm)
- [`TimeOffRequestsApprove`](https://autotask.net/help/DeveloperHelp/Content/APIs/REST/Entities/TimeOffRequestsApproveEntity.htm)
- [`TimeOffRequestsReject`](https://autotask.net/help/DeveloperHelp/Content/APIs/REST/Entities/TimeOffRequestsRejectEntity.htm)

While the `TimeOffRequests` endpoint behaves like most other entities, the associated `Approve` and `Reject` endpoints are create-only.

No tests have been added for these endpoints due the complexity and sensitivity of these endpoints, but I can confirm that they work for us internally with these changes.