### PR TITLE
test(perf): improve test performance by limiting max returned records

### DIFF
--- a/index.test.js
+++ b/index.test.js
@@ -27,18 +27,21 @@ it('can get by id', async () => {
 
 test('can query multiple.', async () => {
 
-  let result = await autotask.Companies.query({filter:[
-    {
-      field: "companyName",
-      op: FilterOperators.beginsWith,
-      value: "A"
-    },
-    {
-      field: "id",
-      op: FilterOperators.gt,
-      value: 0
-    }
-  ]});
+  let result = await autotask.Companies.query({
+    filter: [
+      {
+        field: "companyName",
+        op: FilterOperators.beginsWith,
+        value: "A",
+      },
+      {
+        field: "id",
+        op: FilterOperators.gt,
+        value: 0,
+      },
+    ],
+    MaxRecords: 5,
+  });
   // console.log('query result: %o', result);
   expect(result.items).toBeDefined();
   let item = result.items[0];


### PR DESCRIPTION
This is a small tweak to the "can query multiple" test. Autotask's API is very slow when querying the default number of records (500), so adding a `MaxRecords` property to the search object drastically reduces the amount of time needed for that test.